### PR TITLE
Emg data prep qa hk2

### DIFF
--- a/Prep/fresno_ripa_import.R
+++ b/Prep/fresno_ripa_import.R
@@ -19,7 +19,7 @@ rda <- connect_to_db("rda_shared_data")
 fresno_ripa<-dbGetQuery(rda, "SELECT * FROM crime_and_justice.cadoj_ripa_2022 WHERE agency_name = 'FRESNO PD'")
 
 ## clean up time-zone
-fresno_ripa <- fresno_ripa %>% mutate(date_reformatted=as.POSIXct(date_of_stop,tz="UTC"),
+fresno_ripa <- fresno_ripa %>% mutate(date_reformatted=as.character(as.POSIXct(date_of_stop,tz="UTC",format="%Y-%m-%d")),
                                time_of_stop_reformatted=as_hms(time_of_stop))
 # test result
 View(data.frame(fresno_ripa$doj_record_id,fresno_ripa$date_of_stop,fresno_ripa$date_reformatted,fresno_ripa$time_of_stop,fresno_ripa$time_of_stop_reformatted))


### PR DESCRIPTION
@elyciamg The changes you made look good. 

Per our slack convo, I tried importing the table from pg and R still wants to convert `date_of_stop`. To get around that, we'll set the date as a string. That way we can keep the integrity of the original data and convert to other data types as needed for analysis in R.

See the change in pg here: `cadoj_ripa_fresno_2022_qahk2` - if it looks ok we can rerun the script, re-export all the tables and then [mark complete](https://app.asana.com/0/1207318307532830/1207319198426418)