### PR TITLE
addressing the QA notes for report_citation_traffic_type_stop: after …

### DIFF
--- a/report_main.Rmd
+++ b/report_main.Rmd
@@ -98,10 +98,6 @@ orange <- "#F25922"
 ```
 
 
-```{r table, child= 'report_embeds/report_citation_traffic_type_stop.Rmd'}
-```
-
-
 ### C. Furthermore, use of citations is biased against people of color 
 
 ```{r bubble-chart, child= 'report_embeds/report_traffic_result_citation_race.Rmd'}


### PR DESCRIPTION
…feedback from MY we are removing this ggplot table from the report rmd. NOT knitting the report rmd to html yet.

Noting after getting feedback from My that we are removing this table (ggplot table in report under 2B) altogether. 
See this pull request from branch jz_citation_type_qa where I remove this table from the report for now. (did not reknit the report rmd to html though)
