### PR TITLE
updated WP html for final report page

### DIFF
--- a/_archived/wp_report_page.html
+++ b/_archived/wp_report_page.html
@@ -1,6 +1,6 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600..800&family=Open+Sans:wght@300..800&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600..700&family=Open+Sans:wght@300..800&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://use.typekit.net/kjp5mnx.css">
 
 <style>
@@ -343,10 +343,9 @@ document.addEventListener('DOMContentLoaded', function() {
     <!-- Your main content -->
     <div class="main-content">
         <div id="header">
-
-            <h1 class="title toc-ignore">Driven by Bias: <em>An Analysis of Police Stops in Fresno</em></h1>
+        <h1 id="report-title" class="title toc-ignore">Driven by Bias: <em>An Analysis of Police Stops in Fresno</em></h1>
             <h4 class="author">Catalyst California in partnership with Fresno Building Healthy Communities</h4>
-            <h4 class="date">24 January, 2025</h4>
+            <h4 class="date">18 February, 2025</h4>
 
         </div>
         
@@ -355,8 +354,8 @@ document.addEventListener('DOMContentLoaded', function() {
             residents. This practice undermines community safety, inflicts harm on Black, Indigenous, and People of
             Color (BIPOC) communities, and wastes time and public dollars. We need a new vision of community safety
             and reinvestment to keep our families safe and together.
-        </p>
-        
+        </p>        
+
         <blockquote>
             <p>
                 <strong>“For me, safety in my community means: safe spaces for all intersectionalities, less presence
@@ -366,18 +365,19 @@ document.addEventListener('DOMContentLoaded', function() {
                     immigrants,
                     and access to all resources.” -Fresno community member</strong>
                 <br><br>
+
                 <strong>
                     <em>“Para mí, la seguridad en mi comunidad significa: espacios seguros para todos sin tomar en
                         cuenta su raza, sexo, estado civil, etcétera; menos brutalidad policíaca; más iluminación en las
                         calles de los vecindarios; campañas comunitarias en la comunidad; más aceras, áreas verdes,
                         acceso
                         a parques seguros y limpios; más seguridad en el medio ambiente; justicia y seguridad para los
-                        inmigrantes; y acceso a todos los recursos.” -Miembro de la comunidad de Fresno
+                        inmigrantes; y acceso a todos los recursos.” -Miembro de la comunidad de Fresno<a href="#fn1" class="footnote-ref" id="fnref1"><sup>1</sup></a>
                     </em>
                 </strong>
             </p>
         </blockquote>
-        
+
         <div id="acknowledgements" class="section level1">
             <h1>ACKNOWLEDGEMENTS</h1>
             <p>
@@ -443,12 +443,11 @@ document.addEventListener('DOMContentLoaded', function() {
                         <em>
                             “That we can better trust law enforcement; for example,
                             that we can hold police officers as heroes that don't threaten our
-                            lives.” -Fresno community member<a href="#fn1" class="footnote-ref" id="fnref1"><sup>1</sup></a>
+                            lives.” -Fresno community member
                         </em>
-                    </strong> 
+                    </strong>
                 </p>
             </blockquote>
-            
             <blockquote>
                 <p>
                     <strong>“Mejor[es] calles. Menos basura, más limpieza. Más tiendas,
@@ -788,7 +787,9 @@ document.addEventListener('DOMContentLoaded', function() {
                         no vehicle registration were given to people of color. As explained in
                         the recommendations, these citations inflict financial costs on
                         communities for concerns that could be better addressed through non-law
-                        enforcement alternatives. Comparatively, officers are more likely to
+                        enforcement alternatives.</p>
+
+                    <p>Comparatively, officers are more likely to
                         ticket White people for speeding. Approximately, 66.3% of all citations
                         officers issued to White people were for speeding, compared to 51.3% of
                         citations issued to Latinx people. In other words, tickets for equipment
@@ -1029,7 +1030,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         19 minutes.</p>
 
 
-                    <iframe style="width: 100%; height: 420px; border: none;"
+                    <iframe style="width: 100%; height: 620px; border: none;"
                         src="https://catalystcalifornia.github.io/fresnoripa/report_embeds/report_timespent_traffic_race.html"></iframe>
 
                     <blockquote>
@@ -1109,7 +1110,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         like. Thus, when reimagining community safety, making significant and
                         meaningful investments into this department can promote building out
                         community-care centered infrastructure that keeps communities safe.
-                        However, we see that Fresno PD's budget was 60 percent more than the
+                        However, we see that Fresno PD's budget was 60% more than the
                         PARCS budget.</p>
                     <p> In the context of flexible dollars received by each department,
                         Fresno PD receives far more general fund dollars in comparison to PARCS.
@@ -1364,10 +1365,9 @@ document.addEventListener('DOMContentLoaded', function() {
             <p><strong>Reimagine Justice and Safety</strong></p>
             <p>Chauncee Smith, Associate Director</p>
             <p><strong>REPORT CITATION</strong></p>
-            <p>Catalyst California and Fresno Building Healthy Communities. “Traffic
-                Stops and Race: <em>An Analysis of Police Stops in Fresno</em>.” 2025.
-                <a href="https://fresnobhc.org/driven-by-bias-fresno-pd-report"
-                    class="uri">https://fresnobhc.org/driven-by-bias-fresno-pd-report</a>.
+            <p>Catalyst California and Fresno Building Healthy Communities. “Driven by Bias: <em>An Analysis of Police Stops in Fresno</em>.” 2025.
+                <a href="https://fresnobhc.org/driven-by-bias-fresno-police-department-report/#report"
+                    class="uri">https://fresnobhc.org/driven-by-bias-fresno-police-department-report/#report</a>.
             </p>
             <p><strong>DETAILED METHODOLOGY</strong></p>
             <p>Click <a href="https://github.com/catalystcalifornia/fresnoripa/blob/main/README.md">here</a>


### PR DESCRIPTION
Last bit of housekeeping. 

To migrate our report html to Fresno BHC's website, and improve web performance, we removed some unnecessary boilerplate html that R/highcharter creates in our normal interactive report workflow. 

This file tracks only the essential html, css, and JS used for the live report page. This updated code was sent by Pablo on March 3, 2025 once everything was finalized for the hard launch.